### PR TITLE
Make password constraints consistent.

### DIFF
--- a/system/typemill/Models/Validation.php
+++ b/system/typemill/Models/Validation.php
@@ -263,7 +263,7 @@ class Validation
 		$v = new Validator($params);
 		$v->rule('required', ['username', 'password'])->message("Required");
 		$v->rule('alphaNum', 'username')->message("Invalid characters");
-		$v->rule('lengthBetween', 'password', 5, 20)->message("Length between 5 - 20");
+		$v->rule('lengthBetween', 'password', 5, 40)->message("Length between 5 - 40");
 		$v->rule('lengthBetween', 'username', 3, 20)->message("Length between 3 - 20");
 		
 		if($v->validate())


### PR DESCRIPTION
To avoid confusion, we should probably use the same min and max character lengths for passwords during sign-up and sign-in.

In this case, it felt like the sign-in rules should be made consistent with the sign-up rules (they allow for passwords up to 40 chars in length, which is a little nicer).

Closes https://github.com/typemill/typemill/issues/430