### PR TITLE
fix fieldset recursion

### DIFF
--- a/system/typemill/Models/Fields.php
+++ b/system/typemill/Models/Fields.php
@@ -29,7 +29,7 @@ class Fields
 			{
 				# if it is a fieldset, then create a subset for the containing field and read them with a recursive function
 				$subSettings 			= $objectSettings;
-				$subSettings['forms']	= $fieldConfigurations;
+				$subSettings[$formType]	= $fieldConfigurations;
 				
 				$fieldset 				= array();
 				$fieldset['type'] 		= 'fieldset';


### PR DESCRIPTION
This small change fixes the issue #493.
It fixes an issue were a fieldset is running an endless recursion, if you don't use it inside a 'forms' form. I found this while using a 'public' form. 