### PR TITLE
addJS and addInlineJS allow to specify attributes for tag <script>

### DIFF
--- a/system/typemill/Assets.php
+++ b/system/typemill/Assets.php
@@ -82,19 +82,19 @@ class Assets
 		$this->inlineCSS[] = '<style>' . $CSS . '</style>';
 	}
 	
-	public function addJS($JS)
+	public function addJS($JS, $attr)
 	{
 		$JSfile = $this->getFileUrl($JS);
 		
 		if($JSfile)
 		{
-			$this->JS[] = '<script src="' . $JSfile . '"></script>';
+			$this->JS[] = '<script ' . $attr . ' src="' . $JSfile . '"></script>';
 		}
 	}
 
-	public function addInlineJS($JS)
+	public function addInlineJS($JS, $attr)
 	{
-		$this->inlineJS[] = '<script>' . $JS . '</script>';
+		$this->inlineJS[] = '<script' . $attr . '>' . $JS . '</script>';
 	}
 
 	public function addBloxConfigJS($JS)

--- a/system/typemill/Plugin.php
+++ b/system/typemill/Plugin.php
@@ -201,14 +201,14 @@ abstract class Plugin implements EventSubscriberInterface
 		$this->container->get('view')->getEnvironment()->addFunction($function);
 	}
 
-	protected function addJS($JS)
+	protected function addJS($JS, $attr="")
 	{
-		$this->container->get('assets')->addJS($JS);
+		$this->container->get('assets')->addJS($JS, $attr);
 	}
 
-	protected function addInlineJS($JS)
+	protected function addInlineJS($JS, $attr="")
 	{
-		$this->container->get('assets')->addInlineJS($JS);
+		$this->container->get('assets')->addInlineJS($JS, $attr);
 	}
 
 	protected function addBloxConfigJS($JS)


### PR DESCRIPTION
Hi
I've made a minor patch that allows to specify attributes for the script tag with addJS and addInlineJS.
I need this patch for my plugin https://github.com/josefpavlik/typemill-plugin-figureswipe 
The methods ```addJS``` and ```addInlineJS``` have optional second parameter that is directly injected to <script> tag. It's used for passing attribute type="module", but it can be used to pass any single or multiple attribute. The second parameter is optional, default is empty.
example:
```         $this->addJS('/figureSwipe/figureSwipe.js', 'type="module"');  ```
